### PR TITLE
Debug mode cache clearing, state persistence, and runtime version detection

### DIFF
--- a/.yo-rc.json
+++ b/.yo-rc.json
@@ -7,7 +7,7 @@
       "@microsoft/microsoft-graph-client": "3.0.2",
       "@microsoft/teams-js": "2.12.0"
     },
-    "version": "1.19.0",
+    "version": "1.22.2",
     "libraryName": "PnPSPFxLiveReloader",
     "libraryId": "8efb81af-7fba-40a7-bd48-48a12bdb4c54",
     "environment": "spo",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.3.3 (2026-02-24)
+
+### Bug Fixes
+
+* **Debug Toggle:** Fixed "page stuck" issue when switching debug mode on/off by clearing SPFx component manifest caches from localStorage and sessionStorage (preserves placement preference)
+* **Debug Toggle:** Renamed session storage key from `spfx-debug` to `pnp-lr-debug` to avoid conflicts with other SPFx tooling
+* **Debug Toggle:** Debug connected state is now properly preserved across page navigations instead of being reset on initialization
+* **Debug Toggle:** Simplified plug icon logic to use `debugConnected` state directly, removing unreliable webpack HMR function detection for UI state
+* **Version Detection:** SPFx version is now detected at runtime instead of reading from static `.yo-rc.json`, which was unreliable in deployed scenarios
+
+### Changes
+
+* **Credits Panel:** SPFx version display now shows "Detecting..." on load and updates dynamically once runtime version detection completes
+
 ## 1.3.0 (2026-02-06)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can focus on your code rather than when it is time to reload your browser.
 
 ## Used SharePoint Framework Version
 
-![version](https://img.shields.io/badge/SPFx-1.22.1-green.svg)
+![version](https://img.shields.io/badge/SPFx-1.22.2-green.svg)
 
 ## Applies to
 
@@ -52,6 +52,8 @@ None so far.
 
 | Version | Date             | Comments        |
 | ------- | ---------------- | --------------- |
+| 1.3.3   | February 24, 2026 | Debug toggle fixes, runtime SPFx version detection, reload stuck fix |
+| 1.3     | February 6, 2026 | HMR control: pause/resume, pending updates badge, SPFx version detection |
 | 1.2     | January 28, 2026 | SPFx 1.22 Heft migration, placement toggle, WebSocket fixes |
 | 1.1     | July 23, 2024 | Credits and Branding Information added |
 | 1.0     | July 11, 2024 | Initial release |
@@ -82,7 +84,44 @@ For details look at the [CHANGELOG](CHANGELOG.md)
 
 ## Features
 
-For now just reload the Browser Window once the browser have been reloaded.
+### Automatic Browser Reload
+
+Monitors the SPFx webpack-dev-server for build completion and automatically refreshes the browser window. Works seamlessly with existing SPFx projects with **zero configuration**.
+
+### Dual-Mode Operation
+
+- **Modern Mode (SPFx 1.22+):** Intercepts the webpack Hot Module Replacement (HMR) infrastructure for fine-grained control over live reload updates.
+- **Legacy Mode (SPFx 1.0 - 1.21):** Uses WebSocket connection to `wss://localhost:4321/ws` for full-page reload on build completion.
+
+The correct mode is selected automatically at runtime based on SPFx version detection.
+
+### HMR Control (SPFx 1.22+)
+
+- **Pause / Resume:** Toggle to control when live reload updates are applied, so you can focus on debugging without unexpected refreshes.
+- **Pending Updates Badge:** Shows the count of blocked HMR updates while paused.
+- **Apply Button:** Manually apply accumulated changes on your terms without automatic reload.
+- **Session Persistence:** Pause state is persisted in session storage across page navigations.
+
+### Debug Mode Toggle
+
+- Toggle the debug manifest URL (`?debug=true&noredir=true&debugManifestsFile=...`) on or off with a single click.
+- Automatically clears SPFx component manifest caches when switching modes to prevent stale state.
+- Preserves your placement preference across debug mode toggles.
+
+### Flexible Placement
+
+- Position the Live Reloader bar at the **Header** (top) or **Footer** (bottom) of the page.
+- Placement preference is persisted in localStorage.
+
+### Theme Integration
+
+- Inherits SharePoint theme colors automatically.
+- Supports semantic and palette colors with real-time theme change detection.
+
+### Architecture Diagrams
+
+- [HMR Flow](docs/hmr-flow.svg) — How the HMR interceptor controls webpack hot updates
+- [Version Detection](docs/version-detection.svg) — How SPFx version is detected at runtime
 
 ## References
 

--- a/config/package-solution.json
+++ b/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "PnP SPFx Live Reloader",
     "id": "8efb81af-7fba-40a7-bd48-48a12bdb4c54",
-    "version": "1.3.0.0",
+    "version": "1.3.3.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,
@@ -12,7 +12,7 @@
       "websiteUrl": "",
       "privacyUrl": "",
       "termsOfUseUrl": "",
-      "mpnId": "Undefined-1.19.0"
+      "mpnId": ""
     },
     "metadata": {
       "shortDescription": {
@@ -30,7 +30,7 @@
         "title": "PnP SPFX Live Reloader Application Extension - Deployment of custom action",
         "description": "Deploys a custom action with ClientSideComponentId association",
         "id": "60ba8ce7-813a-486e-9d1a-935a9076f60d",
-        "version": "1.3.0.0",
+        "version": "1.3.3.0",
         "assets": {
           "elementManifests": [
             "elements.xml",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnp-spfx-live-reloader",
-  "version": "1.3.0",
+  "version": "1.3.3",
   "private": true,
   "engines": {
     "node": ">=18.17.1"

--- a/src/extensions/components/Credits.ts
+++ b/src/extensions/components/Credits.ts
@@ -1,6 +1,5 @@
 /* eslint-disable */
 const pkg = require('../../../package.json');
-const yo = require('../../../.yo-rc.json');
 /* eslint-enable */
 
 import { IClientSideComponentManifest } from "@microsoft/sp-module-interfaces";
@@ -21,6 +20,7 @@ export class Credits {
 
     private _dialog: Dialog;
     private _dialogContent: HTMLElement;
+    private _spfxVersionItem!: HTMLLIElement;
 
     private _manifest: IClientSideComponentManifest;
 
@@ -101,9 +101,10 @@ export class Credits {
 
         menu.append(menuItemVersion);
 
-        const menuItemSPFxVersion = document.createElement('li');
+        const menuItemSPFxVersion = document.createElement('li') as HTMLLIElement;
         menuItemSPFxVersion.classList.add('menu-credit-item');
-        menuItemSPFxVersion.innerHTML = `<strong>SPFx Version:</strong> ${yo['@microsoft/generator-sharepoint'].version}`;
+        menuItemSPFxVersion.innerHTML = `<strong>SPFx Version:</strong> Detecting...`;
+        this._spfxVersionItem = menuItemSPFxVersion;
 
         menu.append(menuItemSPFxVersion);
 
@@ -165,6 +166,10 @@ export class Credits {
 
     }
 
+
+    public updateSPFxVersion(version: string | null): void {
+        this._spfxVersionItem.innerHTML = `<strong>SPFx Version:</strong> ${version ?? 'Not detected'}`;
+    }
 
     public get credits(): HTMLDialogElement {
         return this._dialog;

--- a/src/extensions/components/LiveReloadBar.ts
+++ b/src/extensions/components/LiveReloadBar.ts
@@ -273,6 +273,9 @@ export default class LiveReloadBar {
         this._isModernMode = this.isVersion122OrHigher(version);
         lrs.modernMode = this._isModernMode;
 
+        // Update credits panel with the runtime-detected version
+        this._credits.updateSPFxVersion(version);
+
         console.log('🔥 detectAndInitialize: SPFx version=', version, 'modernMode=', this._isModernMode);
 
         if (this._isModernMode) {
@@ -443,25 +446,15 @@ export default class LiveReloadBar {
         this._branding = new Branding();
         this._parentDom.prepend(this._branding.Info);
 
-        // Check if webpack HMR is available (indicates SPFx 1.22+ modern mode)
-        // This is available immediately, unlike the async version detection
-        const hasWebpackHMR = Object.keys(window).some(k => k.startsWith('webpackHotUpdate'));
-
-        // In modern mode (1.22+), always show connected plug since HMR is always active
-        // In legacy mode, show based on debugConnected state
-        const showConnectedPlug = hasWebpackHMR || lrs.debugConnected;
-
-        if (showConnectedPlug) {
-            this._debugConnect = new HooIconButton('icon-plug-connected-filled', { ariaLabel: 'HMR Connected' }, actionBar.Container);
-            if (!hasWebpackHMR) {
-                // Only allow toggling in legacy mode
-                this._debugConnect.addEventListener('click', _evt => {
-                    lrs.debugConnected = false;
-                });
-            }
-        }
-        if (!showConnectedPlug) {
-            this._debugDisconnect = new HooIconButton('icon-plug-disconnected-filled', { ariaLabel: 'HMR Disconnected' }, actionBar.Container);
+        // Show plug icon based on debugConnected state
+        // Toggles the debug manifest URL (?debug=true&noredir=true&debugManifestsFile=...)
+        if (lrs.debugConnected) {
+            this._debugConnect = new HooIconButton('icon-plug-connected-filled', { ariaLabel: 'Debug Connected' }, actionBar.Container);
+            this._debugConnect.addEventListener('click', _evt => {
+                lrs.debugConnected = false;
+            });
+        } else {
+            this._debugDisconnect = new HooIconButton('icon-plug-disconnected-filled', { ariaLabel: 'Debug Disconnected' }, actionBar.Container);
             this._debugDisconnect.addEventListener('click', _evt => {
                 lrs.debugConnected = true;
             });

--- a/src/extensions/pnPSpFxLiveReloader/PnPSpFxLiveReloaderApplicationCustomizer.ts
+++ b/src/extensions/pnPSpFxLiveReloader/PnPSpFxLiveReloaderApplicationCustomizer.ts
@@ -47,7 +47,7 @@ export default class PnPSPFxLiveReloaderApplicationCustomizer
     // LogDebug('INIT LIVE RELOADER STATE\n\t', lrs, connectionResponse);
 
     if (connectionResponse && connectionResponse.status === 200) {
-      lrs.state = { available: true, connected: lrs.connected, debugConnected: false, paused: lrs.paused, pendingCount: lrs.pendingCount, modernMode: lrs.modernMode };
+      lrs.state = { available: true, connected: lrs.connected, debugConnected: lrs.debugConnected, paused: lrs.paused, pendingCount: lrs.pendingCount, modernMode: lrs.modernMode };
     } else {
       lrs.state = { available: false, connected: false, debugConnected: false, paused: false, pendingCount: 0, modernMode: false };
     }


### PR DESCRIPTION
Hi Stefan,

Thank you for building this great tool — it really improves my SPFx development. I am a coding lecturer in M365 in the Czech Republic, and I recommend that students use this app.

While using Live Reloader 1.3.0 with SPFx 1.22.2 in my projects, I ran into a few issues and put together fixes for them. Here is a summary of what this PR addresses:

Bug fixes:

Page gets stuck when toggling debug mode. Switching the debug plug on/off would sometimes leave the page in a broken state because stale SPFx component manifest caches remained in localStorage and sessionStorage. The fix clears both storages when toggling, while preserving the new user's placement preference (header/footer).

Debug connected state resets on page load. In PnPSpFxLiveReloaderApplicationCustomizer.ts, the debugConnected property was hardcoded to false during initialization, which meant the plug icon always started as disconnected even after the user had toggled it on. Now it reads the persisted value from lrs.debugConnected.

Plug icon relied on unreliable detection. The connected/disconnected plug icon was determined by scanning window for webpackHotUpdate* keys, which was not always accurate. Simplified this to use the debugConnected state directly, which is what the user actually controls.

Changes:

Runtime SPFx version detection. The Credits panel previously read the SPFx version from .yo-rc.json via require(). This file is a scaffolding artifact and is not reliably available in deployed scenarios. Replaced it with the runtime version that is already detected by LiveReloadBar.detectAndInitialize(), so the Credits panel now shows "Detecting..." briefly and then updates with the actual version.

Session storage key renamed from spfx-debug to pnp-lr-debug to avoid potential conflicts with other SPFx tooling.

All changes, IMO, are backwards-compatible and do not affect Legacy Mode behaviour.